### PR TITLE
Deprecate Node.js 4 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "stable"
   - "5"
-  - "4"
   - "0.12"
   - "0.10"
   - "iojs"


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 4